### PR TITLE
Two bugfixes and corrected comment. 

### DIFF
--- a/parse_osm.m
+++ b/parse_osm.m
@@ -71,7 +71,11 @@ for i=1:Nways
     Nnd = size(waytemp.nd, 2);
     ndtemp = zeros(1, Nnd);
     for j=1:Nnd
-        ndtemp(1, j) = str2double(waytemp.nd{j}.Attributes.ref);
+        if Nnd == 1
+            ndtemp(1,j) = str2double(waytemp.nd.Attributes.ref);
+        else
+            ndtemp(1, j) = str2double(waytemp.nd{j}.Attributes.ref);
+        end
     end
     nd{1, i} = ndtemp;
     

--- a/plot_way.m
+++ b/plot_way.m
@@ -70,15 +70,23 @@ for i=1:size(way.id, 2)
     nd_ids = node.id;
     for j=1:num_nd
         cur_nd_id = way_nd_ids(1, j);
-        nd_coor(:, j) = node.xy(:, cur_nd_id == nd_ids);
+        if ~isempty(node.xy(:, cur_nd_id == nd_ids))
+             nd_coor(:, j) = node.xy(:, cur_nd_id == nd_ids);
+        end
     end
     
-    % plot way (highway = red, other = green)
-    if flag == 1
-        plot(hax, nd_coor(1,:), nd_coor(2,:), 'b-')
-    else
-        plot(hax, nd_coor(1,:), nd_coor(2,:), 'g--')
+    % remove zeros
+    nd_coor(any(nd_coor==0,2),:)=[];
+    
+    if ~isempty(nd_coor)
+        % plot way (highway = blue, other = green)
+        if flag == 1
+            plot(hax, nd_coor(1,:), nd_coor(2,:), 'b-')
+        else
+            plot(hax, nd_coor(1,:), nd_coor(2,:), 'g--')
+        end
     end
+    
     %waitforbuttonpress
 end
 disp(key_catalog.')


### PR DESCRIPTION
Bugfix, `waytemp.nd` is not a struct if `Nnd == 1`, resulting in an error:

```
??? Cell contents reference from a non-cell array object.

Error in ==> parse_osm>parse_way at 78
ndtemp(1, j) = str2double(waytemp.nd{j}.Attributes.ref);
```

etc..
